### PR TITLE
Fix API key initialization

### DIFF
--- a/app_v2.py
+++ b/app_v2.py
@@ -3,9 +3,14 @@ from google import genai
 import json
 from content import limpar_texto_html, fetch_normativo
 from datetime import datetime
+import os
 
 # Configurações
-KEY = ""
+KEY = os.environ.get("KEY")
+if not KEY:
+    raise RuntimeError(
+        "API key not found. Please set the KEY environment variable."
+    )
 client = genai.Client(api_key=KEY)
 
 SYSTEM_PROMPT = (


### PR DESCRIPTION
## Summary
- read Gemini API key from `KEY` env var and fail early if missing

## Testing
- `python -m py_compile app_v2.py content.py`


------
https://chatgpt.com/codex/tasks/task_e_6880d9bc77008331bea17d6e77f8fbd3